### PR TITLE
Debugging aid for module exceptions

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -67,7 +67,9 @@ function Collector(config) {
     output.push(this._runtime);
 
     this._modules.forEach(function(m) {
-      var src = 'function(require, exports, module) {\n' + m.src +  '\n}';
+      var fnName = 'module$' + m.id.replace(/[^a-z0-9_]+/ig, '$');
+      var src = 'function ' + fnName + '(require, exports, module) {\n' +
+        m.src +  '\n}';
       output.push(this.makeDefine(m, src));
     }, this);
 


### PR DESCRIPTION
Hi Tobie, I made a change to make debugging errors in modules easier. By giving a name to the anonymous module function, the stack trace is much more useful if a module throws an error:

  module$path$to$module
  require
  module$path$to$other
  require
  (anonymous function)

It's worth pointing out that the methods are still anonymous and are not added to the global scope (try it!).
