### PR TITLE
Support for "use strict"

### DIFF
--- a/assets/modulr.sync.js
+++ b/assets/modulr.sync.js
@@ -53,7 +53,7 @@
         // `main` isn't defined until we actually require the program's
         // entry point.
         var r = makeRequire(id, main || mod);
-        fn(r, mod.exports, mod);
+        fn.call(exports, r, mod.exports, mod);
         if (__PERF__) {
           _p.right = _pos++;
           _p.end = Date.now();

--- a/assets/modulr.sync.resolved.js
+++ b/assets/modulr.sync.resolved.js
@@ -45,7 +45,7 @@
     // require.main isn't defined until we actually require the program's
     // entry point.
     if (!require.main) { require.main = mod; }
-    fn(require, mod.exports, mod);
+    fn.call(exports, require, mod.exports, mod);
     if (__PERF__) {
       _p.right = _pos++;
       _p.end = Date.now();


### PR DESCRIPTION
When running in strict mode, and executing a function with explicitly passing a context object, "this === null".
A number of modules (including underscore.js) expects that "this === window" at the global context. This holds true for node.js
Modulr looses this context when executing a factory. Pass the context explicitly.
