### PR TITLE
trim trailing index.js from sourceURL mappings

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -12,7 +12,8 @@ var JS_ESCAPE_REGEXP = /\\|\r?\n|"/g,
        '"': '\\"',
        '</': '<\/'
      },
-     RUNTIME = abstractCollector.getRuntimeSrcCode('modulr.sync.js');
+     RUNTIME = abstractCollector.getRuntimeSrcCode('modulr.sync.js'),
+     INDEX_TRIM_REGEXP = /(.*)\/index/;
 
 exports.createCollector = createCollector;
 exports.create = createCollector;
@@ -94,7 +95,7 @@ util.inherits(Collector, SuperClass);
 
   p.getSourceUrl = getSourceUrl;
   function getSourceUrl(m) {
-    return '\n//@ sourceURL=' + m.relativePath + '\n';
+    return '\n//@ sourceURL=' + m.relativePath.replace(INDEX_TRIM_REGEXP, '$1') + '\n';
   }
 
   p.getModuleId = getModuleId;
@@ -122,4 +123,3 @@ util.inherits(Collector, SuperClass);
     return RUNTIME + '\n';
   }
 })(Collector.prototype);
-


### PR DESCRIPTION
This makes the code much easier to browse in webkit inspector

foo/bar/index.js gets converted to foo/bar.js
