### PR TITLE
Adds the ability to specify module modifiers on a project

### DIFF
--- a/lib/abstract-collector.js
+++ b/lib/abstract-collector.js
@@ -27,6 +27,16 @@ function AbstractCollector(config) {
     this._lazyEvaluatedModules = modules;
   }
 
+  p.setModuleModifiers = setModuleModifiers;
+  function setModuleModifiers(moduleModifiers) {
+    this._moduleModifiers = moduleModifiers;
+  }
+
+  p.setRoot = setRoot;
+  function setRoot(root) {
+    this._root = root;
+  }
+
   p.addMainModule = addMainModule;
   function addMainModule(m) {
     this._main = m;
@@ -45,6 +55,16 @@ function AbstractCollector(config) {
   p.getLazyEvaluatedModules = getLazyEvaluatedModules;
   function getLazyEvaluatedModules() {
     return (this._lazyEvaluatedModules = this._lazyEvaluatedModules || {});
+  }
+
+  p.getModuleModifiers = getModuleModifiers;
+  function getModuleModifiers() {
+    return this._moduleModifiers;
+  }
+
+  p.getRoot = getRoot;
+  function getRoot() {
+    return this._root;
   }
 
   p.render = render;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -42,7 +42,7 @@ function Builder(config) {
           throw new TypeError(msg);
         }
       }
-      
+
       // Find their dependencies.
       lazyEval = this.findScopedDependencies(modules);
     }
@@ -58,11 +58,14 @@ function Builder(config) {
     this.setDevConstant(clonedConsts);
     this.setPerfConstant(clonedConsts);
 
+
     result.lazyEval = lazyEval;
     collector.setLazyEvaluatedModules(lazyEval);
     collector.setModules(deps);
     collector.addMainModule(result.main);
     collector.setConstants(clonedConsts);
+    collector.setRoot(this.config.root);
+    collector.setModuleModifiers(this.config.modifiers);
     return collector.toString();
   }
 

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -1,4 +1,6 @@
 var util = require('util'),
+    fs = require('fs'),
+    path = require('path'),
     abstractCollector = require('./abstract-collector'),
     SuperClass = abstractCollector.AbstractCollector,
     _super = SuperClass.prototype;
@@ -13,6 +15,22 @@ var JS_ESCAPE_REGEXP = /\\|\r?\n|"/g,
        '</': '<\/'
      },
      RUNTIME = abstractCollector.getRuntimeSrcCode('modulr.sync.js');
+
+var moduleModifierCache = {};
+
+/**
+ * Determine if the str variable matches a pattern.  This supports
+ * simple wildcard searches with an asterisk at the end, e.g.
+ * "foo*" would match "foo"
+ */
+function matches(pattern, str) {
+  var asteriskIndex = pattern.indexOf('*');
+  if (asteriskIndex > -1) {
+    str = str.substring(0, asteriskIndex);
+    pattern = pattern.substring(0, asteriskIndex);
+  }
+  return pattern === str;
+}
 
 exports.createCollector = createCollector;
 exports.create = createCollector;
@@ -89,7 +107,7 @@ util.inherits(Collector, SuperClass);
     if (m.duplicateOf) {
       return 'module.exports = require("' + this.getModuleId(m.duplicateOf) + '");'
     }
-    return m.getSrc();
+    return this.getModuleModifier(m, 'start') + m.getSrc() + this.getModuleModifier(m, 'end');
   }
 
   p.getSourceUrl = getSourceUrl;
@@ -101,6 +119,36 @@ util.inherits(Collector, SuperClass);
   p.getModuleId = getModuleId;
   function getModuleId(m) {
     return m.id;
+  }
+
+  p.getModuleModifier = getModuleModifier;
+  function getModuleModifier(m, position) {
+    var modifiers = this.getModuleModifiers();
+    if (!modifiers || modifiers.length === 0) {
+      return '';
+    }
+
+    var str = '';
+
+    for (var i = 0; i < modifiers.length; i++) {
+      if (modifiers[i][position] && matches(modifiers[i].name, m.id)) {
+        // Resolve the path to the script file relative to the project including it
+        var scriptPath = path.resolve(this.getRoot(), modifiers[i][position]);
+
+        // If the script has not already been read and cached, do so.
+        if (!moduleModifierCache[scriptPath]) {
+
+          moduleModifierCache[scriptPath] = fs.readFileSync(scriptPath, 'utf8');
+          if (!moduleModifierCache[scriptPath]) {
+            console.log('Error: Module modifier file not found: ' + scriptPath);
+          }
+        }
+
+        str += '\n' + moduleModifierCache[scriptPath] + '\n';
+      }
+    }
+
+    return str;
   }
 
   p.beforeRequireCall = beforeRequireCall;


### PR DESCRIPTION
Adds the ability to specify module modifiers on a project, to prepend and append scripts to one or more modules.  This should make it much easier to import non-CommonJS projects and not have to modify the source.  It should also make it simpler to put any kind of scripts at the start and end of many modules, perhaps for temporary logging or perf measurements

This change may not be exactly in keeping with how you write Modulr normally, and if so please suggest an alternate home for it that Collector.
