### PR TITLE
Minify module identifiers to make them as small as possible.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,7 @@ require('modulr').build('foo', {
   root: 'path/to/package/root/' // defaults to process.cwd()
   minify: true,                 // defaults to false
   resolveIdentifiers: true,     // defaults to false
+  minifyIdentifiers: false,     // defaults to false
   environment: 'prod' // or 'dev', defaults to undefined
 }, callback);
 
@@ -57,7 +58,7 @@ if (__DEV__) { console.log('Module Foo loaded.'); }
 Minification
 ------------
 
-`modulr` uses [Uglify](https://github.com/mishoo/UglifyJS/) to optionally minify the output. To enable minification, set the `minify` config option to `true`. Note that minification is not compatible with the `"dev"` environment.
+`modulr` uses [Uglify](https://github.com/mishoo/UglifyJS/) to optionally minify the output. To enable minification, set the `minify` config option to `true`. To also minify module identifiers, set the `minifyIdentifiers` option to `true`. Note that minification is not compatible with the `"dev"` environment.
 
 ```javascript
 require('modulr').build('foo', { minify: true }, callback);

--- a/lib/resolved-ast-collector.js
+++ b/lib/resolved-ast-collector.js
@@ -6,6 +6,12 @@ var util = require('util'),
     walker = uglify.uglify.ast_walker(),
     identifier = require('module-grapher/lib/identifier');
 
+var uniqueId = 0;
+var map = {};
+function generateId(id) {
+  return (map[id] ? map[id] : (map[id] = (uniqueId++).toString(36)));
+}
+
 var RUNTIME = astCollector.getRuntimeAst('modulr.sync.resolved.js');
 
 exports.createResolvedAstCollector = createResolvedAstCollector;
@@ -40,7 +46,11 @@ util.inherits(ResolvedAstCollector, SuperClass);
   p.getModuleIdAst = getModuleIdAst;
   function getModuleIdAst(m) {
     if (this.config.minify) {
-      return ["string", m.getHashCode()];
+      var moduleId = m.getHashCode();
+      if (this.config.minifyIdentifiers) {
+        moduleId = generateId(moduleId);
+      }
+      return ["string", moduleId];
     } else {
       while (m.duplicateOf) {
         m = m.duplicateOf;

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ function build(main, config, callback) {
     callback = config;
     config = {};
   }
-  if (config.minify && config.cache) {
+  if ((config.minify || config.minifyIdentifiers) && config.cache) {
     var err = new Error('Cannot minify code when using cache.');
     callback(err);
     return;


### PR DESCRIPTION
This change makes module identifier as short as possible when using the minify option.

MD5-Hashes are 32-characters long and can have a slight impact on file size, depending on the scale of a project. This new approach uses a regular counter and encodes the module id as base36 String. The advantage is that module identifiers will almost certainly stay within a two character limit as there are 1,296 possible two-character module ids.

File size impact in our application ( https://github.com/auphonic/auphonic-mobile ):
MD5-Hashes: 283k uncompressed, 68k gzip compressed
Strings: 272k uncompressed, 63k gzip compressed

As you can see, this gives us 5k (!) when using gzip compression. Feel free to confirm this yourself by downloading the git repository, running npm install and Scripts/compile with and without the change applied in node_modules/modulr-node
